### PR TITLE
utilise l'hostname plutot que l'origin pour determiner github.com

### DIFF
--- a/assets/scripts/actions/current-repository.js
+++ b/assets/scripts/actions/current-repository.js
@@ -135,7 +135,8 @@ export const setBaseUrlInConfigIfNecessary = async baseUrl => {
   if (baseUrl) {
     newBaseUrl = baseUrl.replace(/\/$/, '')
   } else {
-    if (currentRepository.origin === 'https://github.com') {
+    let hostname = new URL(currentRepository.origin).hostname;
+    if (hostname === 'github.com') {
       const publishedWebsiteURL = await currentRepository.publishedWebsiteURL
       const url = new URL(publishedWebsiteURL)
 


### PR DESCRIPTION
Pas sûr que ça aide, mais au cas où (et j'ai pas pu tester, je n'arrive pas à mettre en place une instance de Scribouilli sur les pages de mon fork…).